### PR TITLE
#15 feat : 주간메뉴평가 기능 추가 및 코드 구조 변경

### DIFF
--- a/Index.js
+++ b/Index.js
@@ -20,6 +20,7 @@ const square = require('./square');
 const schedule = require('./schedule');
 const searchPlace = require('./searchPlace');
 const todayMenu = require('./todayMenu');
+const weeklyMenu = require('./weeklyMenu');
 
 let Ishaksa = 0;
 
@@ -50,6 +51,9 @@ rtm.on('message', (message) => {
           break;
         case '오늘 밥 뭐야':
           todayMenu(rtm, channel);
+          break;
+        case '이번주 뭐 나와':
+          weeklyMenu(rtm, channel);
           break;
         case '학사일정':
           Ishaksa = 1;

--- a/getMenu.js
+++ b/getMenu.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable global-require */
+const getMenu = async function (daynum) {
+  const axios = require('axios');
+  const cheerio = require('cheerio');
+
+  const url = 'https://sobi.chonbuk.ac.kr/menu/week_menu.php';
+  const selector = `#contents > div.contentsArea.WeekMenu > div:nth-child(247) > div:nth-child(2) > table > tbody > tr:nth-child(1) > td:nth-child(${daynum}) > ul`;
+  const res = [];
+  let html;
+  let $;
+  try {
+    html = await axios.get(url);
+    $ = cheerio.load(html.data);
+    for (const v of $(selector).find('li')) {
+      if ($(v).text() !== '') {
+        res.push($(v).text());
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+  return res;
+};
+
+module.exports = getMenu;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.2.0",
         "cheerio": "^1.0.0-rc.12",
         "dotenv": "^16.0.3",
+        "js-levenshtein": "^1.1.6",
         "protobufjs": "^7.1.2"
       },
       "devDependencies": {
@@ -1926,6 +1927,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
@@ -4303,6 +4312,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
     "js-sdsl": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.2.0",
     "cheerio": "^1.0.0-rc.12",
     "dotenv": "^16.0.3",
+    "js-levenshtein": "^1.1.6",
     "protobufjs": "^7.1.2"
   },
   "devDependencies": {

--- a/rating.js
+++ b/rating.js
@@ -1,4 +1,4 @@
-const rating = function (menu, rtm, channel) {
+const rating = function (menu) {
   const menuArr = menu.toString().split(',');
 
   const prefer = '닭,돼지,고기,치즈,두부,짬뽕,오리,소,파스타,새우';
@@ -24,12 +24,14 @@ const rating = function (menu, rtm, channel) {
   }
 
   if (score <= 1) {
-    rtm.sendMessage('★☆☆', channel);
-  } else if (score === 2) {
-    rtm.sendMessage('★★☆', channel);
-  } else if (score >= 3) {
-    rtm.sendMessage('★★★', channel);
+    return '★☆☆';
+  } if (score === 2) {
+    return '★★☆';
+  } if (score >= 3) {
+    return '★★★';
   }
+
+  return '';
 };
 
 module.exports = rating;

--- a/todayMenu.js
+++ b/todayMenu.js
@@ -1,31 +1,7 @@
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable global-require */
-
 const rating = require('./rating');
+const getMenu = require('./getMenu');
 
 const todayMenu = function (rtm, channel) {
-  const axios = require('axios');
-  const cheerio = require('cheerio');
-
-  async function webScraping(url, selector) {
-    const res = [];
-    let html;
-    let $;
-    try {
-      html = await axios.get(url);
-      $ = cheerio.load(html.data);
-      for (const v of $(selector).find('li')) {
-        if ($(v).text() !== '') {
-          res.push($(v).text());
-        }
-      }
-    } catch (error) {
-      console.error(error);
-    }
-
-    return res;
-  }
-
   const dayDict = {};
   dayDict[1] = 3;
   dayDict[2] = 4;
@@ -41,15 +17,12 @@ const todayMenu = function (rtm, channel) {
     rtm.sendMessage('오늘은 주말입니다.', channel);
   } else {
     const daynum = dayDict[day];
-
-    const url = 'https://sobi.chonbuk.ac.kr/menu/week_menu.php';
-    const selector = `#contents > div.contentsArea.WeekMenu > div:nth-child(245) > div:nth-child(2) > table > tbody > tr:nth-child(1) > td:nth-child(${daynum})`;
-
-    webScraping(url, selector).then((res) => {
+    getMenu(daynum).then((res) => {
       for (let i = 0; i < res.length; i += 1) {
         rtm.sendMessage(res[i], channel);
       }
-      rating(res, rtm, channel);
+      const rate = rating(res, rtm, channel);
+      rtm.sendMessage(rate, channel);
     });
   }
 };

--- a/weeklyMenu.js
+++ b/weeklyMenu.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-await-in-loop */
+const rating = require('./rating');
+const getMenu = require('./getMenu');
+
+const weeklyMenu = function (rtm, channel) {
+  const dayList = {};
+  dayList[1] = '월';
+  dayList[2] = '화';
+  dayList[3] = '수';
+  dayList[4] = '목';
+  dayList[5] = '금';
+
+  const dayRating = {};
+
+  async function asyncForEach(callback) {
+    for (let i = 1; i < 6; i += 1) {
+      const res = await callback(i);
+      dayRating[i] = rating(res, rtm, channel);
+      rtm.sendMessage(`${dayList[i]} : ${dayRating[i]}`, channel);
+    }
+  }
+
+  asyncForEach(getMenu);
+};
+
+module.exports = weeklyMenu;


### PR DESCRIPTION
#15 

<코드 구조 변경>
1. getMenu.js (추가) => 기존에 있던 웹크롤링 함수를 따로 분리해 모듈화 시켰습니다. 요일에 해당하는 숫자를 input으로 받고 해당 요일의 식단 배열을 return 합니다.

2. weeklyMenu.js (추가) => 이번 주 메뉴에 대한 평가를 출력합니다. <반복문 내 getMenu.js 동기적으로 처리>
                     
4. rating.js (수정) => 평점 챗봇에 직접 출력 (rtm.sendMessage)-> 평점 결과 return 

5. todayMenu.js (수정) => 웹 크롤링 부분 분리 

